### PR TITLE
Faster, more accurate & fault-tolerant log/exp functions

### DIFF
--- a/fastapprox/src/fastexp.h
+++ b/fastapprox/src/fastexp.h
@@ -51,13 +51,11 @@
 static inline float
 fastpow2 (float p)
 {
-  float offset = (p < 0) ? 1.0f : 0.0f;
-  float clipp = (p < -126) ? -126.0f : p;
-  int w = clipp;
-  float z = clipp - w + offset;
-  union { uint32_t i; float f; } v = { cast_uint32_t ( (1 << 23) * (clipp + 121.2740575f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z) ) };
-
-  return v.f;
+  union {float f; uint32_t i;} xv = {p + 383.f}, zv;
+  zv.i = 0x3f800000u | ((xv.i & 0x7fffu) << 8u);
+  xv.f = xv.f - 4.23579f + 27.7280f / (5.84252568f - zv.f) - 1.49012907f * zv.f;
+  xv.i = ((((xv.i < 0x43808000u) ? 0u : xv.i) << 8u) & 0x7FFFFF00);
+  return xv.f;
 }
 
 static inline float
@@ -69,9 +67,9 @@ fastexp (float p)
 static inline float
 fasterpow2 (float p)
 {
-  float clipp = (p < -126) ? -126.0f : p;
-  union { uint32_t i; float f; } v = { cast_uint32_t ( (1 << 23) * (clipp + 126.94269504f) ) };
-  return v.f;
+  union {float f; uint32_t i;} xv = {p + 382.95695f};
+  xv.i = ((((xv.i < 0x43808000u) ? 0u : xv.i) << 8u) & 0x7FFFFF00);
+  return xv.f;
 }
 
 static inline float

--- a/fastapprox/src/fastlog.h
+++ b/fastapprox/src/fastlog.h
@@ -47,14 +47,13 @@
 static inline float 
 fastlog2 (float x)
 {
-  union { float f; uint32_t i; } vx = { x };
-  union { uint32_t i; float f; } mx = { (vx.i & 0x007FFFFF) | 0x3f000000 };
-  float y = vx.i;
-  y *= 1.1920928955078125e-7f;
-
-  return y - 124.22551499f
-           - 1.498030302f * mx.f 
-           - 1.72587999f / (0.3520887068f + mx.f);
+  union {float f; uint32_t i;} xv = {x}, lv, mx;
+  mx.i = 0x3f000000u | (xv.i & 0x007FFFFFu);
+  lv.i = 0x43800000u | (xv.i >> 8u);
+  
+  return lv.f - 380.22544f
+              - 1.498030302f * mx.f
+              - 1.72587999f / (0.3520887068f + mx.f);
 }
 
 static inline float
@@ -66,10 +65,9 @@ fastlog (float x)
 static inline float 
 fasterlog2 (float x)
 {
-  union { float f; uint32_t i; } vx = { x };
-  float y = vx.i;
-  y *= 1.1920928955078125e-7f;
-  return y - 126.94269504f;
+  union {float f; uint32_t i;} xv = {x}, lv;
+  lv.i = 0x43800000u | (xv.i >> 8u);
+  return (lv.f - 382.95695f);
 }
 
 static inline float
@@ -77,10 +75,9 @@ fasterlog (float x)
 {
 //  return 0.69314718f * fasterlog2 (x);
 
-  union { float f; uint32_t i; } vx = { x };
-  float y = vx.i;
-  y *= 8.2629582881927490e-8f;
-  return y - 87.989971088f;
+  union {float f; uint32_t i;} xv = {x}, lv;
+  lv.i = 0x43800000u | (xv.i >> 8u);
+  return 0.69314718f * (lv.f - 382.95695f);
 }
 
 #ifdef __SSE2__


### PR DESCRIPTION
I've been experimenting with fast approximation functions as an evening hobby lately.  This started with a project to generalize the fast-inverse-square-root hack, and I may create another pull request to add a collection of fast roots and inverse roots to fastapprox.

With this PR, I've modified the scalar functions to use fast float-to-int conversion, avoiding int/float casts.

```cpp
  //fasterlog2abs
  union {float f; uint32_t i;} xv = {x}, lv;
  lv.i = 0x43800000u | (xv.i >> 8u);
  return (lv.f - 382.95695f);
```

This results in an appreciable improvement in speed and appears to improve accuracy as well (I did a little tuning).  The modified functions are also a little more fault tolerant, with `log` functions acting as `log(abs(x))` and `exp` functions flushing to zero for very small arguments.

These changes should be simple to generalize to SSE but I've decided to submit this PR without those changes.  I believe small further improvements in the accuracy of fastlog2 and fastpow2 are possible by experimenting with the coefficients, but in any case all modified functions exhibit a reduction in worst-case error in my tests.

Error and performance statistics on the modified functions, here designated "abs".  I tested on an x86_64 MacBook pro.  My testbed tries every float within an exponential range rather than sampling randomly.

```
	Approximate log2(x) with fasterlog2abs
	Error:
		RMS:  0.0236228
		mean: -0.0145537
		min:  -0.0430415 @ 0.180279
		max:  0.0430603 @ 0.125
	Approximate log2(x) with fasterlog2
	Error:
		RMS:  0.0220738
		mean: 8.36081e-06
		min:  -0.0287746 @ 2.88496
		max:  0.0573099 @ 3.99998
	Approximate log2(x) with fastlog2abs
	Error:
		RMS:  4.62902e-05
		mean: -6.39351e-06
		min:  -8.9407e-05 @ 0.226345
		max:  8.79765e-05 @ 5.66174
	Approximate log2(x) with fastlog2
	Error:
		RMS:  8.78776e-05
		mean: -6.90928e-05
		min:  -0.000150681 @ 7.22098
		max:  1.16825e-05 @ 5.67368
	Approximate 2^x with fasterpow2abs
	Error:
		RMS:  0.0204659
		mean: 0.0103297
		min:  -0.0294163 @ 1.04308
		max:  0.0302728 @ 1.48549
	Approximate 2^x with fasterpow2
	Error:
		RMS:  0.0176322
		mean: 0.000165732
		min:  -0.038947 @ 1.05731
		max:  0.0201453 @ 1.50017
	Approximate 2^x with fastpow2abs
	Error:
		RMS:  2.02567e-05
		mean: 7.34409e-07
		min:  -6.03545e-05 @ 1.14546
		max:  6.67494e-05 @ 1.00017
	Approximate 2^x with fastpow2
	Error:
		RMS:  2.84377e-05
		mean: -2.16665e-05
		min:  -6.83582e-05 @ 1.13344
		max:  2.30076e-05 @ 1.99999

   CPU TIME  |  FORMULA    
------------ + ------------
    60345257 | y (baseline for other measurements)
    40318946 | fasterlog2
     4506380 | fasterlog2abs
    36011548 | fastlog2
    31941574 | fastlog2abs
   120095855 | std::log2
    14267362 | fasterpow2abs
    18984349 | fasterpow2
    67782074 | fastpow2abs
    95174888 | fastpow2
    33921997 | std::exp2
------------ + ------------
    54152142 | y (baseline for other measurements)
    19949223 | fasterlog2
    12560614 | fasterlog2abs
    41892165 | fastlog2
    36505168 | fastlog2abs
   125374347 | std::log2
    20324629 | fasterpow2abs
    25769136 | fasterpow2
    73251135 | fastpow2abs
   100127989 | fastpow2
    41127741 | std::exp2
------------ + ------------
    54386750 | y (baseline for other measurements)
    23603119 | fasterlog2
    15133763 | fasterlog2abs
    62677897 | fastlog2
    47765052 | fastlog2abs
   124088143 | std::log2
    21256368 | fasterpow2abs
    25930862 | fasterpow2
    73285208 | fastpow2abs
   103932786 | fastpow2
    39983032 | std::exp2
------------ + ------------
```